### PR TITLE
Fix/getwd error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,6 +46,8 @@ func DefaultConfig() Config {
 	if _, err := os.Stat(notesDir); os.IsNotExist(err) {
 		cwd, err := os.Getwd()
 		if err != nil {
+			// if couldn't get work dir 
+			// trying create default in ~/notes/
 			err := os.MkdirAll(notesDir, 0755)
 			if  err != nil {
 				fmt.Printf("Error finding notes directory: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -54,8 +54,9 @@ func DefaultConfig() Config {
 				os.Exit(1)
 			} 
 			log.Printf("Could not get current directory. Notes dir: %s", notesDir)
+		} else {
+			notesDir = cwd
 		}
-		notesDir = cwd
 	}
 	
 	return Config{

--- a/main.go
+++ b/main.go
@@ -44,7 +44,15 @@ func DefaultConfig() Config {
 	
 	// If ~/notes doesn't exist, use current directory
 	if _, err := os.Stat(notesDir); os.IsNotExist(err) {
-		cwd, _ := os.Getwd()
+		cwd, err := os.Getwd()
+		if err != nil {
+			err := os.MkdirAll(notesDir, 0755)
+			if  err != nil {
+				fmt.Printf("Error finding notes directory: %v\n", err)
+				os.Exit(1)
+			} 
+			log.Printf("Could not get current directory. Notes dir: %s", notesDir)
+		}
 		notesDir = cwd
 	}
 	


### PR DESCRIPTION
### What this PR does

Adds error handling for `os.Getwd()` failure by falling back to a default `~/notes/` directory.

---

### Motivation

In some edge cases (e.g. running the app from a restricted environment), `os.Getwd()` may return an error.
To prevent the application from crashing in such cases, we fallback to a known writable location.

See [Issue #36](https://github.com/pdxmph/notes-tui/issues/36) for context.

---

### Logic Overview

- If `os.Getwd()` fails:
    - Tries to create `~/notes/` directory
        - If successful: logs a warning that default location was created
        - If failed: logs the error and exits the app

---

### Notes

- This keeps the app functional even in unusual environments.
- The log message informs the user that the fallback was used.
